### PR TITLE
Add Option to Delete List Elements After Download

### DIFF
--- a/alexa_shopping_list_scrapper/config.yaml
+++ b/alexa_shopping_list_scrapper/config.yaml
@@ -17,6 +17,7 @@ options:
   HA_Webhook_URL: "HOME_ASSISTANT_WEBHOOK_URL"
   Amazon_Sign_in_URL: "https://www.amazon.com/ap/signin?openid.pape.max_auth_age=3600&openid.return_to=https%3A%2F%2Fwww.amazon.com%2Falexaquantum%2Fsp%2FalexaShoppingList%3Fref_%3Dlist_d_wl_ys_list_1&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_alexa_quantum_us&openid.mode=checkid_setup&language=en_US&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0"
   Amazon_Shopping_List_Page: "https://www.amazon.com/alexaquantum/sp/alexaShoppingList?ref_=list_d_wl_ys_list_1"
+  Delete_After_Download: False
 schema:
   Amazon_Login: str
   Amazon_Pass: password
@@ -25,3 +26,4 @@ schema:
   Amazon_Sign_in_URL: str
   Amazon_Shopping_List_Page: str
   log_level: list(debug|info)?
+  Delete_After_Download: bool

--- a/alexa_shopping_list_scrapper/rootfs/app/scrapeAmazon.js
+++ b/alexa_shopping_list_scrapper/rootfs/app/scrapeAmazon.js
@@ -11,6 +11,7 @@ function getEnvVariable(key) {
 const secret = getEnvVariable('AMZ_SECRET');
 const amz_login = getEnvVariable('AMZ_LOGIN');
 const amz_password = getEnvVariable('AMZ_PASS');
+const delete_after_download = getEnvVariable('DELETE_AFTER_DOWNLOAD');
 const log_level = getEnvVariable('log_level');
 const amz_signin_url = getEnvVariable('Amazon_Sign_in_URL');
 const amz_shoppinglist_url = getEnvVariable('Amazon_Shopping_List_Page');
@@ -110,6 +111,12 @@ async function getOTP(secret) {
 
   // Convert the array to JSON format
   let jsonFormattedItems = JSON.stringify(formattedItems, null, 2);
+
+  if(delete_after_download) {
+      let delete_buttons = await page.$$eval(".item-actions-2 button", button =>
+          button.click()
+      );
+  }
 
   
   // Save the JSON formatted list to default.htm

--- a/alexa_shopping_list_scrapper/rootfs/app/scrapeAmazon.js
+++ b/alexa_shopping_list_scrapper/rootfs/app/scrapeAmazon.js
@@ -112,7 +112,7 @@ async function getOTP(secret) {
   // Convert the array to JSON format
   let jsonFormattedItems = JSON.stringify(formattedItems, null, 2);
 
-  if(delete_after_download) {
+  if(delete_after_download == "true") {
       let delete_buttons = await page.$$eval(".item-actions-2 button", buttons =>
           buttons.forEach(button => button.click())
       );

--- a/alexa_shopping_list_scrapper/rootfs/app/scrapeAmazon.js
+++ b/alexa_shopping_list_scrapper/rootfs/app/scrapeAmazon.js
@@ -113,8 +113,8 @@ async function getOTP(secret) {
   let jsonFormattedItems = JSON.stringify(formattedItems, null, 2);
 
   if(delete_after_download) {
-      let delete_buttons = await page.$$eval(".item-actions-2 button", button =>
-          button.click()
+      let delete_buttons = await page.$$eval(".item-actions-2 button", buttons =>
+          buttons.forEach(button => button.click())
       );
   }
 

--- a/alexa_shopping_list_scrapper/rootfs/app/script.sh
+++ b/alexa_shopping_list_scrapper/rootfs/app/script.sh
@@ -20,6 +20,7 @@ echo HA_WEBHOOK_URL=$(bashio::config 'HA_Webhook_URL')>>.env
 echo log_level=$(bashio::config 'log_level')>>.env
 echo Amazon_Sign_in_URL=$(bashio::config 'Amazon_Sign_in_URL')>>.env
 echo Amazon_Shopping_List_Page=$(bashio::config 'Amazon_Shopping_List_Page')>>.env
+echo DELETE_AFTER_DOWNLOAD=$(bashio::config 'Delete_After_Download')>>.env
 
 COMMANDS=(
     "cd /app/"


### PR DESCRIPTION
I don't use the Alexa shopping list myself, but only to add entries to my Home Assistant instance via Alexa voice. It therefore makes sense to delete the entries after scraping them to prevent the list from growing indefinitely.

Another advantage of this method is that the blueprint can be reduced, as it is no longer necessary to check whether an entry has already been added. This also allows entries to be imported correctly if they have been added multiple times via language. Previously, these were only added once, as a comparison was only made on the basis of the name.